### PR TITLE
Drill+EMRFS

### DIFF
--- a/watershed/aws_tools/emr.py
+++ b/watershed/aws_tools/emr.py
@@ -80,7 +80,9 @@ def launch_emr_cluster(s3_config=None, emr_config=None, profile="default", wait_
                 'Path': 's3://elasticmapreduce/bootstrap-actions/configure-hadoop',
                 'Args': [
                     "--hdfs-key-value",
-                    "dfs.replication=3"
+                    "dfs.replication=3",
+                    "--core-key-value",
+                    "io.compression.codecs=org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.BZip2Codec,org.apache.hadoop.io.compress.SnappyCodec"
                 ]
             }
         },

--- a/watershed/conf/defaults.json
+++ b/watershed/conf/defaults.json
@@ -52,7 +52,7 @@
     ],
     "archives": [
       {
-        "dfsUrl": "s3n://AccessKey:SecretKey@watershed",
+        "dfsUrl": "s3://AccessKey:SecretKey@watershed",
         "path": "/stream-archives",
         "name": "app_event"
       }

--- a/watershed/resources/s3/emr/exec/setup_drill
+++ b/watershed/resources/s3/emr/exec/setup_drill
@@ -238,6 +238,7 @@ def installDrill(targetDir, runDir, logDir)
     installZookeeper("/home/hadoop/drill", "#{runDir}/zookeeper", "#{logDir}/zookeeper")
 
     println "Configuring Apache Drill..."
+    sudo "ln -s /home/hadoop/conf/core-site.xml #{targetDir}/#{drillRoot}/conf/core-site.xml"
     sudo "chown -R hadoop.hadoop /home/hadoop/.versions/*drill*"
     sudo "mkdir -p #{runDir} && mkdir -p #{logDir}"
     sudo "chown -R hadoop.hadoop #{runDir}"

--- a/watershed/resources/s3/emr/exec/setup_drill_lib_aws
+++ b/watershed/resources/s3/emr/exec/setup_drill_lib_aws
@@ -26,6 +26,12 @@ for f in /home/hadoop/share/hadoop/common/lib/emr-*.jar; do
   cp -af $f /home/hadoop/drill/jars/3rdparty/
 done
 
+cp -af /usr/share/aws/emr/emrfs/lib/emrfs-1.8.0.jar /home/hadoop/drill/jars/3rdparty/
+cp -af /usr/share/aws/emr/emrfs/lib/guice-3.0.jar /home/hadoop/drill/jars/3rdparty/
+cp -af /usr/share/aws/emr/emrfs/lib/commons-exec-1.2.jar /home/hadoop/drill/jars/3rdparty/
+cp -af /home/hadoop/lib/emr-s3distcp-1.0.jar /home/hadoop/drill/jars/3rdparty/
+cp -af /usr/share/aws/emr/emrfs/lib/jscience-4.3.1.jar /home/hadoop/drill/jars/3rdparty/
+
 #TODO be more selective with aws-java-sdk;
 #maybe leverage https://github.com/awslabs/emr-bootstrap-actions/blob/master/gradle/install-gradle-bootstrap.sh
 for pattern in aws-java-sdk gson; do


### PR DESCRIPTION
- add necessary jars to drill for emrfs reading
- remove LZO encryption from the core-site.xml "io.compression.codecs" field (because its not installed - drill wont start with it in there)
- point drill at the core-site.xml file