### PR TITLE
Forward Pump port and ignore Pump build directory

### DIFF
--- a/watershed/aws_tools/s3.py
+++ b/watershed/aws_tools/s3.py
@@ -49,6 +49,10 @@ def upload_pump(s3_config=None, profile="default", force_upload=False):
         pump_root = os.path.dirname(os.path.abspath(__file__)).replace('/watershed/aws_tools', '/pump')
         
         for dirpath, dirs, files in os.walk(pump_root):
+            if "build" in dirpath:
+                print("Skipping build directory: {0}".format(dirpath))
+                continue
+                
             for file in files:
                 s3_file_path = s3_config['resourcesPrefix'] + dirpath.replace(pump_root, "/pump") + "/" + file
                 s3_resource.Object(s3_config['resourcesBucket'], s3_file_path).put(Body=open(dirpath + "/" + file, 'rb'))

--- a/watershed/ssh_tools/ssh.py
+++ b/watershed/ssh_tools/ssh.py
@@ -31,7 +31,8 @@ def forward_necessary_ports(cluster_id=None, private_key_path=None, profile='def
         'namenode_port': 9101,
         'zookeeper_port': 2181,
         'drill_user_port': 31010,
-        'hive_port': 10000
+        'hive_port': 10000,
+        'pump_port': 8080
     }
 
     port_forwarders = []


### PR DESCRIPTION
- forwards pump port during "forward-local-ports" stage
- ignore build directory when uploading to s3 incase someone builds Pump locally (filtered out during "upload-resources" stage)