### PR TITLE
Pump client

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,92 @@ provide a unified and de-duplicated SQL view spanning current and archived Amazo
         * `CLUSTER_ID` should be the Cluster ID of the cluster you want to query, i.e. `j-XXXXXXXXXXXXX`
         * `PRIVATE_KEY_FILE` should be the private key setup for your EMR configuration, i.e. `/path/to/key.pem`
         * `WATERSHED_CONFIG` should be the location of your configuration, i.e. `/path/to/defaults.json`
+        
+# pump
+Pump gives you a way to query, modify, and re-emit data to an Amazon Kinesis Stream.
+
+* Pump is deployed during watershed's "launch-cluster" command.
+
+
+# pump client
+Interact with pump via the pump client provided in the main watershed directory.
+
+```
+> python3 -m pump_client -h
+Client to manage and monitor Pump.
+
+positional arguments:
+  {create-job,preview-job,get-job,get-all-jobs}
+    create-job          Enqueue a job for Pump to work on.
+    preview-job         Preview a job before Pump runs it.
+    get-job             Retreive Job status from Pump.
+    get-all-jobs        Retreive all Jobs and their statuses from Pump.
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+## Create Job
+Submit a job to Pump - queries Drill, transforms records, emits to Kinesis stream.
+
+```
+> python3 -m pump_client create-job -h
+usage: /private/projects/watershed/pump_client create-job [-h] -q QUERY -s
+                                                          STREAM [-p]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -q QUERY, --query QUERY
+                        Specify the query Pump will use to pull records out of
+                        Drill.
+  -s STREAM, --stream STREAM
+                        Specify the Kinesis stream that Pump will emit records
+                        to.
+  -p, --show-progress   Poll Pump for progress of job
+```
+
+## Preview Job
+Preview a Job before running it - queries Drill and returns the first N results.
+
+```
+> python3 -m pump_client preview-job -h
+usage: /private/projects/watershed/pump_client preview-job [-h] -q QUERY -n
+                                                           NUM_RECORDS
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -q QUERY, --query QUERY
+                        Specify the query Pump will use to pull records out of
+                        Drill.
+  -n NUM_RECORDS, --num-records NUM_RECORDS
+                        Specify the number of records to return in the
+                        preview.
+```
+
+## Get Job
+After submitting, use this to retrieve a Job from Pump to see its status.
+
+```
+> python3 -m pump_client get-job -h
+usage: /private/projects/watershed/pump_client get-job [-h] -id JOB_ID [-p]
+                                                       [-t]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -id JOB_ID, --job-id JOB_ID
+                        Specify the Job ID to retrieve.
+  -p, --show-progress   Poll Pump for progress of job
+  -t, --summary-only    Only show summary information about the Job
+```
+
+## Get all Jobs
+Show all statuses for Jobs that have been submitted during the session.
+
+```
+> python3 -m pump_client get-all-jobs -h
+usage: /private/projects/watershed/pump_client get-all-jobs [-h] [-t]
+
+optional arguments:
+  -h, --help          show this help message and exit
+  -t, --summary-only  Only show summary information about the Job
+```

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
@@ -136,7 +136,7 @@ public class Job {
     }
 
     public String getMeanRatePretty() {
-        return getElapsedTime() > 0 && getMeanRate() != null? String.format("%.1f rec/s", getMeanRate()) : "∞ rec/s";
+        return getElapsedTime() > 0 && getMeanRate() != null? String.format("%.1f rec/s", getMeanRate()) : "--- rec/s";
     }
 
     @Override

--- a/pump/src/test/groovy/com/commercehub/watershed/pump/model/JobSpec.groovy
+++ b/pump/src/test/groovy/com/commercehub/watershed/pump/model/JobSpec.groovy
@@ -92,7 +92,7 @@ class JobSpec extends Specification{
 
         then:
         meanRate == null
-        job.getMeanRatePretty() == "∞ rec/s"
+        job.getMeanRatePretty() == "--- rec/s"
     }
 
     def "getMeanRate: elapsed time is not 0, successfulRecordCount + failureRecordCount is 0"(){

--- a/pump_client.py
+++ b/pump_client.py
@@ -1,0 +1,210 @@
+# Copyright (C) 2015 Commerce Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import requests
+import json
+import os
+
+_pump_port = 8080
+_base_url = 'http://localhost:{}/pump'.format(_pump_port)
+
+def get_argument_parser():
+    _fc_description = "Client to manage and monitor Pump."
+
+    _query_args = ["-q", "--query"]
+    _query_kwargs = dict(action="store", help="Specify the query Pump will use to pull records out of Drill.", required=True, type=str)
+    
+    _stream_args = ["-s", "--stream"]
+    _stream_kwargs = dict(action="store", help="Specify the Kinesis stream that Pump will emit records to.", required=True, type=str)
+    
+    _num_records_args = ["-n", "--num-records"]
+    _num_records_kwargs = dict(action="store", help="Specify the number of records to return in the preview.", required=True, type=int)
+    
+    _job_id_args = ["-id", "--job-id"]
+    _job_id_kwargs = dict(action="store", help="Specify the Job ID to retrieve.", required=True, type=str)
+    
+    _show_progress_args = ["-p", "--show-progress"]
+    _show_progress_kwargs = dict(action="store_const", const=True, required=False, help="Poll Pump for progress of job")
+    
+    _summary_only_args = ["-t", "--summary-only"]
+    _summary_only_kwargs = dict(action="store_const", const=True, required=False, help="Only show summary information about the Job")
+
+    parser = argparse.ArgumentParser(
+        prog=os.path.dirname(__file__),
+        description=_fc_description,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    subparsers = parser.add_subparsers()
+    
+    create_job_parser = subparsers.add_parser('create-job', help="Enqueue a job for Pump to work on.")
+    create_job_parser.set_defaults(which="create-job")
+    create_job_parser.add_argument(*_query_args, **_query_kwargs)
+    create_job_parser.add_argument(*_stream_args, **_stream_kwargs)
+    create_job_parser.add_argument(*_show_progress_args, **_show_progress_kwargs)
+    
+    preview_job_parser = subparsers.add_parser('preview-job', help="Preview a job before Pump runs it.")
+    preview_job_parser.set_defaults(which="preview-job")
+    preview_job_parser.add_argument(*_query_args, **_query_kwargs)
+    preview_job_parser.add_argument(*_num_records_args, **_num_records_kwargs)
+    
+    get_job_parser = subparsers.add_parser('get-job', help="Retreive Job status from Pump.")
+    get_job_parser.set_defaults(which="get-job")
+    get_job_parser.add_argument(*_job_id_args, **_job_id_kwargs)
+    get_job_parser.add_argument(*_show_progress_args, **_show_progress_kwargs)
+    get_job_parser.add_argument(*_summary_only_args, **_summary_only_kwargs)
+    
+    get_all_jobs_parser = subparsers.add_parser('get-all-jobs', help="Retreive all Jobs and their statuses from Pump.")
+    get_all_jobs_parser.set_defaults(which="get-all-jobs")    
+    get_all_jobs_parser.add_argument(*_summary_only_args, **_summary_only_kwargs)
+
+    return parser
+        
+def get_all_jobs(summary_only):
+    print('Showing all jobs...')
+
+    url = _base_url + '/jobs'
+    jobs = []
+    try:
+        r = requests.get(url)
+        jobs = json.loads(r.text)
+    except requests.exceptions.RequestException as e: 
+        print(e)
+        
+    for job in jobs:
+        print_job(job, summary_only)
+    return
+
+
+def get_job(job_id, poll_for_progress, summary_only):        
+    print('Showing job...')
+    print('Job: {}'.format(job_id))
+    
+    url = _base_url + '/jobs/' + job_id
+        
+    while True:
+        job = dict()
+        
+        try:
+            r = requests.get(url)
+            print(r)
+            job = json.loads(r.text)
+        except requests.exceptions.RequestException as e: 
+            print(e)
+
+        if("jobId" not in job):
+            print("Invalid job!")
+            print(job)
+            return
+        
+        print_job(job, summary_only)
+        
+        if(not poll_for_progress or job["stage"] == "COMPLETED_ERROR" or job["stage"] == "COMPLETED_SUCCESS"):
+            break
+            
+        sleep(1)
+    
+    return
+
+
+def print_job(job, summary_only):
+    if(summary_only):        
+        print('{jobId}: {stage}({elapsedTime}, {meanRate}) {successCount} successful, {failureCount} failed, {pendingCount} pending'.format(
+                jobId=job["jobId"],
+                stage=job["stage"],
+                elapsedTime=job["elapsedTimePretty"],
+                meanRate=job["meanRatePretty"],
+                successCount=job["successfulRecordCount"],
+                failureCount=job["failureRecordCount"],
+                pendingCount=job["pendingRecordCount"]
+            ))
+    else:
+        print(json.dumps(job, sort_keys=True, indent=4, separators=(',', ': ')))
+    
+
+def create_job(query_in, stream_out, poll_for_progress):    
+    print('Creating job...')
+    print('Query: {}'.format(query_in))
+    print('Stream: {}'.format(stream_out))
+    print('Polling?: {}'.format(poll_for_progress))
+    
+    url = _base_url + '/jobs'
+    payload = { 'queryIn': query_in, 'streamOut': stream_out }
+    
+    job = dict()
+    try:
+        r = requests.post(url, data=json.dumps(payload), headers={'content-type': 'application/json'})
+        job = json.loads(r.text)
+    except requests.exceptions.RequestException as e: 
+        print(e)
+        
+    if(not poll_for_progress):
+        print(job)
+        return
+        
+    if(not 'jobId' in job):
+        return
+
+    get_job(job.jobId, poll_for_progress, True)
+    return
+
+def preview_job(query_in, num_records):
+    print('Previewing job...')
+    print('Query: {}'.format(query_in))
+    print('Num records: {}'.format(num_records))
+    
+    url = _base_url + '/jobs/preview'
+    jobPreview = dict()
+    try:
+        payload = { 'queryIn': query_in, 'previewCount': num_records }
+        r = requests.post(url, data=json.dumps(payload), headers={'content-type': 'application/json'})
+        print(r)
+        jobPreview = json.loads(r.text)
+    except requests.exceptions.RequestException as e: 
+        print(e)
+    
+    return
+
+
+def main():
+    parser = get_argument_parser()
+    args = parser.parse_args()
+    if(not vars(args)):
+        parser.print_help()
+        parser.exit(1)
+    
+    config = dict()
+    if hasattr(args, 'which'):
+        if args.which == "create-job":
+            create_job(args.query, args.stream, args.show_progress)
+              
+        elif args.which == "get-job":
+            get_job(args.job_id, args.show_progress, args.summary_only)
+        
+        elif args.which == "get-all-jobs":
+            get_all_jobs(args.summary_only)
+        
+        elif args.which == "preview-job":
+            preview_job(args.query, args.num_records)
+        
+        else:
+            parser.print_help()
+            exit(2)
+            
+    else:
+        parser.print_help()
+        exit(2)
+        
+main()

--- a/pump_client/PumpClient.py
+++ b/pump_client/PumpClient.py
@@ -14,6 +14,7 @@
 
 import requests
 import json
+import time
 
 class PumpClient:    
     def __init__(self, base_url):
@@ -31,7 +32,7 @@ class PumpClient:
             print(e)
 
         for job in jobs:
-            print_job(job, summary_only)
+            self.print_job(job, summary_only)
         return
 
 
@@ -55,17 +56,17 @@ class PumpClient:
             if("jobId" not in job):
                 raise Exception('Invalid job.')
 
-            print_job(job, summary_only)
+            self.print_job(job, summary_only)
 
             if(not poll_for_progress or job["stage"] == "COMPLETED_ERROR" or job["stage"] == "COMPLETED_SUCCESS"):
                 break
 
-            sleep(1)
+            time.sleep(1)
 
         return
 
 
-    def print_job(job, summary_only):
+    def print_job(self, job, summary_only):
         if(summary_only):        
             print('{jobId}: {stage}({elapsedTime}, {meanRate}) {successCount} successful, {failureCount} failed, {pendingCount} pending'.format(
                     jobId=job["jobId"],
@@ -98,13 +99,13 @@ class PumpClient:
             raise
 
         if(not poll_for_progress):
-            print(job)
+            self.print_job(job, True)
             return
 
         if(not 'jobId' in job):
             return
 
-        get_job(job.jobId, poll_for_progress, True)
+        self.get_job(job['jobId'], poll_for_progress, True)
         return
 
     def preview_job(self, query_in, num_records):

--- a/pump_client/PumpClient.py
+++ b/pump_client/PumpClient.py
@@ -105,6 +105,7 @@ class PumpClient:
         if(not 'jobId' in job):
             return
 
+        print('Submitted job ID={}'.format(job["jobId"]))
         self.get_job(job['jobId'], poll_for_progress, True)
         return
 

--- a/pump_client/PumpClient.py
+++ b/pump_client/PumpClient.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2015 Commerce Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+import json
+
+class PumpClient:    
+    def __init__(self, base_url):
+        self._base_url = base_url
+    
+    def get_all_jobs(self, summary_only):
+        print('Showing all jobs...')
+
+        url = self._base_url + '/jobs'
+        jobs = []
+        try:
+            r = requests.get(url)
+            jobs = json.loads(r.text)
+        except requests.exceptions.RequestException as e: 
+            print(e)
+
+        for job in jobs:
+            print_job(job, summary_only)
+        return
+
+
+    def get_job(self, job_id, poll_for_progress, summary_only):        
+        print('Showing job...')
+        print('Job: {}'.format(job_id))
+
+        url = self._base_url + '/jobs/' + job_id
+
+        while True:
+            job = dict()
+
+            try:
+                r = requests.get(url)
+                print(r)
+                job = json.loads(r.text)
+            except requests.exceptions.RequestException as e: 
+                print(e)
+                raise
+
+            if("jobId" not in job):
+                raise Exception('Invalid job.')
+
+            print_job(job, summary_only)
+
+            if(not poll_for_progress or job["stage"] == "COMPLETED_ERROR" or job["stage"] == "COMPLETED_SUCCESS"):
+                break
+
+            sleep(1)
+
+        return
+
+
+    def print_job(job, summary_only):
+        if(summary_only):        
+            print('{jobId}: {stage}({elapsedTime}, {meanRate}) {successCount} successful, {failureCount} failed, {pendingCount} pending'.format(
+                    jobId=job["jobId"],
+                    stage=job["stage"],
+                    elapsedTime=job["elapsedTimePretty"],
+                    meanRate=job["meanRatePretty"],
+                    successCount=job["successfulRecordCount"],
+                    failureCount=job["failureRecordCount"],
+                    pendingCount=job["pendingRecordCount"]
+                ))
+        else:
+            print(json.dumps(job, sort_keys=True, indent=4, separators=(',', ': ')))
+
+
+    def create_job(self, query_in, stream_out, poll_for_progress):    
+        print('Creating job...')
+        print('Query: {}'.format(query_in))
+        print('Stream: {}'.format(stream_out))
+        print('Polling?: {}'.format(poll_for_progress))
+
+        url = self._base_url + '/jobs'
+        payload = { 'queryIn': query_in, 'streamOut': stream_out }
+
+        job = dict()
+        try:
+            r = requests.post(url, data=json.dumps(payload), headers={'content-type': 'application/json'})
+            job = json.loads(r.text)
+        except requests.exceptions.RequestException as e: 
+            print(e)
+            raise
+
+        if(not poll_for_progress):
+            print(job)
+            return
+
+        if(not 'jobId' in job):
+            return
+
+        get_job(job.jobId, poll_for_progress, True)
+        return
+
+    def preview_job(self, query_in, num_records):
+        print('Previewing job...')
+        print('Query: {}'.format(query_in))
+        print('Num records: {}'.format(num_records))
+
+        url = self._base_url + '/jobs/preview'
+        jobPreview = dict()
+        try:
+            payload = { 'queryIn': query_in, 'previewCount': num_records }
+            r = requests.post(url, data=json.dumps(payload), headers={'content-type': 'application/json'})
+            print(r)
+            jobPreview = json.loads(r.text)
+        except requests.exceptions.RequestException as e: 
+            print(e)
+            raise
+
+        print('Row preview:')
+        for row in jobPreview["rows"]:
+            print(row)
+
+        print('Total number of rows: {}'.format(jobPreview["count"]))
+        return

--- a/pump_client/__main__.py
+++ b/pump_client/__main__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (C) 2015 Commerce Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,31 +15,28 @@
 # limitations under the License.
 
 import argparse
-import requests
-import json
 import os
 
-_pump_port = 8080
-_base_url = 'http://localhost:{}/pump'.format(_pump_port)
+from pump_client.PumpClient import PumpClient
 
 def get_argument_parser():
     _fc_description = "Client to manage and monitor Pump."
 
     _query_args = ["-q", "--query"]
     _query_kwargs = dict(action="store", help="Specify the query Pump will use to pull records out of Drill.", required=True, type=str)
-    
+
     _stream_args = ["-s", "--stream"]
     _stream_kwargs = dict(action="store", help="Specify the Kinesis stream that Pump will emit records to.", required=True, type=str)
-    
+
     _num_records_args = ["-n", "--num-records"]
     _num_records_kwargs = dict(action="store", help="Specify the number of records to return in the preview.", required=True, type=int)
-    
+
     _job_id_args = ["-id", "--job-id"]
     _job_id_kwargs = dict(action="store", help="Specify the Job ID to retrieve.", required=True, type=str)
-    
+
     _show_progress_args = ["-p", "--show-progress"]
     _show_progress_kwargs = dict(action="store_const", const=True, required=False, help="Poll Pump for progress of job")
-    
+
     _summary_only_args = ["-t", "--summary-only"]
     _summary_only_kwargs = dict(action="store_const", const=True, required=False, help="Only show summary information about the Job")
 
@@ -48,156 +47,52 @@ def get_argument_parser():
     )
 
     subparsers = parser.add_subparsers()
-    
+
     create_job_parser = subparsers.add_parser('create-job', help="Enqueue a job for Pump to work on.")
     create_job_parser.set_defaults(which="create-job")
     create_job_parser.add_argument(*_query_args, **_query_kwargs)
     create_job_parser.add_argument(*_stream_args, **_stream_kwargs)
     create_job_parser.add_argument(*_show_progress_args, **_show_progress_kwargs)
-    
+
     preview_job_parser = subparsers.add_parser('preview-job', help="Preview a job before Pump runs it.")
     preview_job_parser.set_defaults(which="preview-job")
     preview_job_parser.add_argument(*_query_args, **_query_kwargs)
     preview_job_parser.add_argument(*_num_records_args, **_num_records_kwargs)
-    
+
     get_job_parser = subparsers.add_parser('get-job', help="Retreive Job status from Pump.")
     get_job_parser.set_defaults(which="get-job")
     get_job_parser.add_argument(*_job_id_args, **_job_id_kwargs)
     get_job_parser.add_argument(*_show_progress_args, **_show_progress_kwargs)
     get_job_parser.add_argument(*_summary_only_args, **_summary_only_kwargs)
-    
+
     get_all_jobs_parser = subparsers.add_parser('get-all-jobs', help="Retreive all Jobs and their statuses from Pump.")
     get_all_jobs_parser.set_defaults(which="get-all-jobs")    
     get_all_jobs_parser.add_argument(*_summary_only_args, **_summary_only_kwargs)
 
     return parser
-        
-def get_all_jobs(summary_only):
-    print('Showing all jobs...')
 
-    url = _base_url + '/jobs'
-    jobs = []
-    try:
-        r = requests.get(url)
-        jobs = json.loads(r.text)
-    except requests.exceptions.RequestException as e: 
-        print(e)
-        
-    for job in jobs:
-        print_job(job, summary_only)
-    return
-
-
-def get_job(job_id, poll_for_progress, summary_only):        
-    print('Showing job...')
-    print('Job: {}'.format(job_id))
-    
-    url = _base_url + '/jobs/' + job_id
-        
-    while True:
-        job = dict()
-        
-        try:
-            r = requests.get(url)
-            print(r)
-            job = json.loads(r.text)
-        except requests.exceptions.RequestException as e: 
-            print(e)
-
-        if("jobId" not in job):
-            print("Invalid job!")
-            print(job)
-            return
-        
-        print_job(job, summary_only)
-        
-        if(not poll_for_progress or job["stage"] == "COMPLETED_ERROR" or job["stage"] == "COMPLETED_SUCCESS"):
-            break
-            
-        sleep(1)
-    
-    return
-
-
-def print_job(job, summary_only):
-    if(summary_only):        
-        print('{jobId}: {stage}({elapsedTime}, {meanRate}) {successCount} successful, {failureCount} failed, {pendingCount} pending'.format(
-                jobId=job["jobId"],
-                stage=job["stage"],
-                elapsedTime=job["elapsedTimePretty"],
-                meanRate=job["meanRatePretty"],
-                successCount=job["successfulRecordCount"],
-                failureCount=job["failureRecordCount"],
-                pendingCount=job["pendingRecordCount"]
-            ))
-    else:
-        print(json.dumps(job, sort_keys=True, indent=4, separators=(',', ': ')))
-    
-
-def create_job(query_in, stream_out, poll_for_progress):    
-    print('Creating job...')
-    print('Query: {}'.format(query_in))
-    print('Stream: {}'.format(stream_out))
-    print('Polling?: {}'.format(poll_for_progress))
-    
-    url = _base_url + '/jobs'
-    payload = { 'queryIn': query_in, 'streamOut': stream_out }
-    
-    job = dict()
-    try:
-        r = requests.post(url, data=json.dumps(payload), headers={'content-type': 'application/json'})
-        job = json.loads(r.text)
-    except requests.exceptions.RequestException as e: 
-        print(e)
-        
-    if(not poll_for_progress):
-        print(job)
-        return
-        
-    if(not 'jobId' in job):
-        return
-
-    get_job(job.jobId, poll_for_progress, True)
-    return
-
-def preview_job(query_in, num_records):
-    print('Previewing job...')
-    print('Query: {}'.format(query_in))
-    print('Num records: {}'.format(num_records))
-    
-    url = _base_url + '/jobs/preview'
-    jobPreview = dict()
-    try:
-        payload = { 'queryIn': query_in, 'previewCount': num_records }
-        r = requests.post(url, data=json.dumps(payload), headers={'content-type': 'application/json'})
-        print(r)
-        jobPreview = json.loads(r.text)
-    except requests.exceptions.RequestException as e: 
-        print(e)
-    
-    return
-
-
-def main():
+if __name__ == "__main__":
     parser = get_argument_parser()
     args = parser.parse_args()
     if(not vars(args)):
         parser.print_help()
         parser.exit(1)
+        
+    pumpClient = PumpClient('http://localhost:8080/pump')
     
     config = dict()
     if hasattr(args, 'which'):
         if args.which == "create-job":
-            create_job(args.query, args.stream, args.show_progress)
+            pumpClient.create_job(args.query, args.stream, args.show_progress)
               
         elif args.which == "get-job":
-            get_job(args.job_id, args.show_progress, args.summary_only)
+            pumpClient.get_job(args.job_id, args.show_progress, args.summary_only)
         
         elif args.which == "get-all-jobs":
-            get_all_jobs(args.summary_only)
+            pumpClient.get_all_jobs(args.summary_only)
         
         elif args.which == "preview-job":
-            preview_job(args.query, args.num_records)
+            pumpClient.preview_job(args.query, args.num_records)
         
         else:
             parser.print_help()
@@ -206,5 +101,3 @@ def main():
     else:
         parser.print_help()
         exit(2)
-        
-main()

--- a/pump_client/__main__.py
+++ b/pump_client/__main__.py
@@ -101,3 +101,4 @@ if __name__ == "__main__":
     else:
         parser.print_help()
         exit(2)
+        

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,12 @@ if __name__ == "__main__":
         long_description=long_description,
         packages=[
             "watershed",
+            "pump_client"
         ],
         install_requires=[
             "Boto3",
-            "sshtunnel"
+            "sshtunnel",
+            "requests"
         ],
         test_requires=[
             'nose',


### PR DESCRIPTION
Note: Please merge https://github.com/commercehub-oss/watershed/pull/59 first.

# Pump Client
```
> python3 -m pump_client -h
Client to manage and monitor Pump.

positional arguments:
  {create-job,preview-job,get-job,get-all-jobs}
    create-job          Enqueue a job for Pump to work on.
    preview-job         Preview a job before Pump runs it.
    get-job             Retreive Job status from Pump.
    get-all-jobs        Retreive all Jobs and their statuses from Pump.

optional arguments:
  -h, --help            show this help message and exit
```

### Create Job
Submit a job to Pump - queries Drill, transforms records, emits to Kinesis stream.
```
> python3 -m pump_client create-job -h
usage: /private/projects/watershed/pump_client create-job [-h] -q QUERY -s
                                                          STREAM [-p]

optional arguments:
  -h, --help            show this help message and exit
  -q QUERY, --query QUERY
                        Specify the query Pump will use to pull records out of
                        Drill.
  -s STREAM, --stream STREAM
                        Specify the Kinesis stream that Pump will emit records
                        to.
  -p, --show-progress   Poll Pump for progress of job
```

### Preview Job
Preview a Job before running it - queries Drill and returns the first N results.
```
> python3 -m pump_client preview-job -h
usage: /private/projects/watershed/pump_client preview-job [-h] -q QUERY -n
                                                           NUM_RECORDS

optional arguments:
  -h, --help            show this help message and exit
  -q QUERY, --query QUERY
                        Specify the query Pump will use to pull records out of
                        Drill.
  -n NUM_RECORDS, --num-records NUM_RECORDS
                        Specify the number of records to return in the
                        preview.
```

### Get Job
After submitting, use this to retrieve a Job from Pump to see its status.
```
> python3 -m pump_client get-job -h
usage: /private/projects/watershed/pump_client get-job [-h] -id JOB_ID [-p]
                                                       [-t]

optional arguments:
  -h, --help            show this help message and exit
  -id JOB_ID, --job-id JOB_ID
                        Specify the Job ID to retrieve.
  -p, --show-progress   Poll Pump for progress of job
  -t, --summary-only    Only show summary information about the Job
```

### Get all Jobs
Show all statuses for Jobs that have been submitted during the session.
```
> python3 -m pump_client get-all-jobs -h
usage: /private/projects/watershed/pump_client get-all-jobs [-h] [-t]

optional arguments:
  -h, --help          show this help message and exit
  -t, --summary-only  Only show summary information about the Job
```