### PR TITLE
Track last successful record

### DIFF
--- a/pump/src/main/java/com/commercehub/watershed/pump/application/PumpGuiceModule.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/application/PumpGuiceModule.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.github.davidmoten.rx.jdbc.ConnectionProvider;
 import com.github.davidmoten.rx.jdbc.Database;
 import com.google.inject.AbstractModule;
-import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/DrillResultRow.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/DrillResultRow.java
@@ -2,4 +2,4 @@ package com.commercehub.watershed.pump.model;
 
 import java.util.HashMap;
 
-public class ResultRow extends HashMap<String, String> {}
+public class DrillResultRow extends HashMap<String, String> {}

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
@@ -29,7 +29,7 @@ public class Job {
 
     private ProcessingStage stage = ProcessingStage.NOT_STARTED;
 
-    private ResultRow lastSuccessfulRow;
+    private DrillResultRow lastSuccessfulRow;
 
     private PeriodFormatter formatter = new PeriodFormatterBuilder()
             .printZeroNever().appendHours().appendSuffix(" hour, ", " hours, ")
@@ -141,11 +141,11 @@ public class Job {
         return getElapsedTime() > 0 && getMeanRate() != null? String.format("%.1f rec/s", getMeanRate()) : "--- rec/s";
     }
 
-    public ResultRow getLastSuccessfulRow() {
+    public DrillResultRow getLastSuccessfulRow() {
         return lastSuccessfulRow;
     }
 
-    public void setLastSuccessfulRow(ResultRow lastSuccessfulRow) {
+    public void setLastSuccessfulRow(DrillResultRow lastSuccessfulRow) {
         this.lastSuccessfulRow = lastSuccessfulRow;
     }
 

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
@@ -1,6 +1,5 @@
 package com.commercehub.watershed.pump.model;
 
-import com.amazonaws.services.kinesis.model.Record;
 import com.commercehub.watershed.pump.service.TimeService;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/Job.java
@@ -1,5 +1,6 @@
 package com.commercehub.watershed.pump.model;
 
+import com.amazonaws.services.kinesis.model.Record;
 import com.commercehub.watershed.pump.service.TimeService;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -28,6 +29,8 @@ public class Job {
     private DateTime completionTime;
 
     private ProcessingStage stage = ProcessingStage.NOT_STARTED;
+
+    private ResultRow lastSuccessfulRow;
 
     private PeriodFormatter formatter = new PeriodFormatterBuilder()
             .printZeroNever().appendHours().appendSuffix(" hour, ", " hours, ")
@@ -139,6 +142,14 @@ public class Job {
         return getElapsedTime() > 0 && getMeanRate() != null? String.format("%.1f rec/s", getMeanRate()) : "--- rec/s";
     }
 
+    public ResultRow getLastSuccessfulRow() {
+        return lastSuccessfulRow;
+    }
+
+    public void setLastSuccessfulRow(ResultRow lastSuccessfulRow) {
+        this.lastSuccessfulRow = lastSuccessfulRow;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -152,9 +163,10 @@ public class Job {
             return false;
         if (pumpSubscription != null ? !pumpSubscription.equals(job.pumpSubscription) : job.pumpSubscription != null)
             return false;
+        if (lastSuccessfulRow != null ? !lastSuccessfulRow.equals(job.lastSuccessfulRow) : job.lastSuccessfulRow != null)
+            return false;
 
         return stage == job.stage;
-
     }
 
     @Override
@@ -163,6 +175,7 @@ public class Job {
         result = 31 * result + pumpSettings.hashCode();
         result = 31 * result + (processingErrors != null ? processingErrors.hashCode() : 0);
         result = 31 * result + (pumpSubscription != null ? pumpSubscription.hashCode() : 0);
+        result = 31 * result + (lastSuccessfulRow != null ? lastSuccessfulRow.hashCode() : 0);
         result = 31 * result + stage.hashCode();
         return result;
     }

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/JobPreview.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/JobPreview.java
@@ -16,16 +16,8 @@ public class JobPreview {
         return count;
     }
 
-    public void setCount(Integer count) {
-        this.count = count;
-    }
-
     public List<Map<String, String>> getRows() {
         return rows;
-    }
-
-    public void setRows(List<Map<String, String>> rows) {
-        this.rows = rows;
     }
 
     @Override

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
@@ -2,6 +2,9 @@ package com.commercehub.watershed.pump.model;
 
 import com.amazonaws.services.kinesis.model.Record;
 
+/**
+ * Holds both a KinesisRecord and the ResultRow retrieved from Drill.
+ */
 public class PumpRecord {
     Record kinesisRecord;
     ResultRow drillRow;
@@ -11,10 +14,18 @@ public class PumpRecord {
         this.drillRow = drillRow;
     }
 
+    /**
+     * Retrieve the Kinesis record
+     * @return Record
+     */
     public Record getKinesisRecord() {
         return kinesisRecord;
     }
 
+    /**
+     * Retrieve the Drill row
+     * @return ResultRow
+     */
     public ResultRow getDrillRow() {
         return drillRow;
     }

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
@@ -1,0 +1,21 @@
+package com.commercehub.watershed.pump.model;
+
+import com.amazonaws.services.kinesis.model.Record;
+
+public class PumpRecord {
+    Record kinesisRecord;
+    ResultRow drillRow;
+
+    public PumpRecord(Record kinesisRecord, ResultRow drillRow) {
+        this.kinesisRecord = kinesisRecord;
+        this.drillRow = drillRow;
+    }
+
+    public Record getKinesisRecord() {
+        return kinesisRecord;
+    }
+
+    public ResultRow getDrillRow() {
+        return drillRow;
+    }
+}

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
@@ -3,15 +3,15 @@ package com.commercehub.watershed.pump.model;
 import com.amazonaws.services.kinesis.model.Record;
 
 /**
- * Holds both a KinesisRecord (pre-emission) and the ResultRow retrieved from Drill.
+ * Holds both a KinesisRecord (pre-emission) and the DrillResultRow retrieved from Drill.
  */
 public class PumpRecord {
     Record kinesisRecord;
-    ResultRow drillRow;
+    DrillResultRow drillResultRow;
 
-    public PumpRecord(Record kinesisRecord, ResultRow drillRow) {
+    public PumpRecord(Record kinesisRecord, DrillResultRow drillResultRow) {
         this.kinesisRecord = kinesisRecord;
-        this.drillRow = drillRow;
+        this.drillResultRow = drillResultRow;
     }
 
     /**
@@ -24,9 +24,9 @@ public class PumpRecord {
 
     /**
      * Retrieve the Drill row
-     * @return ResultRow
+     * @return DrillResultRow
      */
-    public ResultRow getDrillRow() {
-        return drillRow;
+    public DrillResultRow getDrillResultRow() {
+        return drillResultRow;
     }
 }

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecord.java
@@ -3,7 +3,7 @@ package com.commercehub.watershed.pump.model;
 import com.amazonaws.services.kinesis.model.Record;
 
 /**
- * Holds both a KinesisRecord and the ResultRow retrieved from Drill.
+ * Holds both a KinesisRecord (pre-emission) and the ResultRow retrieved from Drill.
  */
 public class PumpRecord {
     Record kinesisRecord;

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
@@ -1,0 +1,21 @@
+package com.commercehub.watershed.pump.model;
+
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
+
+public class PumpRecordResult {
+    private UserRecordResult userRecordResult;
+    private ResultRow resultRow;
+
+    public PumpRecordResult(UserRecordResult userRecordResult, ResultRow resultRow) {
+        this.userRecordResult = userRecordResult;
+        this.resultRow = resultRow;
+    }
+
+    public UserRecordResult getUserRecordResult() {
+        return userRecordResult;
+    }
+
+    public ResultRow getResultRow() {
+        return resultRow;
+    }
+}

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
@@ -2,6 +2,9 @@ package com.commercehub.watershed.pump.model;
 
 import com.amazonaws.services.kinesis.producer.UserRecordResult;
 
+/**
+ * Holds results for the KinesisRecord and the row that was pulled from Drill.
+ */
 public class PumpRecordResult {
     private UserRecordResult userRecordResult;
     private ResultRow resultRow;
@@ -11,10 +14,18 @@ public class PumpRecordResult {
         this.resultRow = resultRow;
     }
 
+    /**
+     * Get the Kinesis UserRecordResult
+     * @return UserRecordResult
+     */
     public UserRecordResult getUserRecordResult() {
         return userRecordResult;
     }
 
+    /**
+     * Get the row that was pulled from Drill.
+     * @return
+     */
     public ResultRow getResultRow() {
         return resultRow;
     }

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
@@ -3,7 +3,7 @@ package com.commercehub.watershed.pump.model;
 import com.amazonaws.services.kinesis.producer.UserRecordResult;
 
 /**
- * Holds results for the KinesisRecord and the row that was pulled from Drill.
+ * Holds results for the KinesisRecord (post-emission) and the row that was pulled from Drill.
  */
 public class PumpRecordResult {
     private UserRecordResult userRecordResult;

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/PumpRecordResult.java
@@ -7,11 +7,11 @@ import com.amazonaws.services.kinesis.producer.UserRecordResult;
  */
 public class PumpRecordResult {
     private UserRecordResult userRecordResult;
-    private ResultRow resultRow;
+    private DrillResultRow drillResultRow;
 
-    public PumpRecordResult(UserRecordResult userRecordResult, ResultRow resultRow) {
+    public PumpRecordResult(UserRecordResult userRecordResult, DrillResultRow drillResultRow) {
         this.userRecordResult = userRecordResult;
-        this.resultRow = resultRow;
+        this.drillResultRow = drillResultRow;
     }
 
     /**
@@ -26,7 +26,7 @@ public class PumpRecordResult {
      * Get the row that was pulled from Drill.
      * @return
      */
-    public ResultRow getResultRow() {
-        return resultRow;
+    public DrillResultRow getDrillResultRow() {
+        return drillResultRow;
     }
 }

--- a/pump/src/main/java/com/commercehub/watershed/pump/model/ResultRow.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/model/ResultRow.java
@@ -1,0 +1,5 @@
+package com.commercehub.watershed.pump.model;
+
+import java.util.HashMap;
+
+public class ResultRow extends HashMap<String, String> {}

--- a/pump/src/main/java/com/commercehub/watershed/pump/processing/JobRunnable.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/processing/JobRunnable.java
@@ -1,14 +1,13 @@
 package com.commercehub.watershed.pump.processing;
 
-import com.amazonaws.services.kinesis.producer.UserRecordResult;
 import com.commercehub.watershed.pump.application.factories.PumpFactory;
 import com.commercehub.watershed.pump.application.factories.PumpSubscriberFactory;
+import com.commercehub.watershed.pump.model.PumpRecordResult;
 import com.commercehub.watershed.pump.model.Job;
 import com.commercehub.watershed.pump.model.ProcessingStage;
 import com.commercehub.watershed.pump.model.PumpSettings;
 import com.commercehub.watershed.pump.service.TransformerFunctionFactory;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.assistedinject.Assisted;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +59,7 @@ public class JobRunnable implements Runnable {
             }
         }, "KPL shutdown hook"));
 
-        Observable<UserRecordResult> results = pump.build();
+        Observable<PumpRecordResult> results = pump.build();
         Subscription subscription = results.subscribe(pumpSubscriberFactory.create(job, pump));
         job.setPumpSubscription(subscription);
     }

--- a/pump/src/main/java/com/commercehub/watershed/pump/processing/JobRunnable.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/processing/JobRunnable.java
@@ -2,9 +2,9 @@ package com.commercehub.watershed.pump.processing;
 
 import com.commercehub.watershed.pump.application.factories.PumpFactory;
 import com.commercehub.watershed.pump.application.factories.PumpSubscriberFactory;
-import com.commercehub.watershed.pump.model.PumpRecordResult;
 import com.commercehub.watershed.pump.model.Job;
 import com.commercehub.watershed.pump.model.ProcessingStage;
+import com.commercehub.watershed.pump.model.PumpRecordResult;
 import com.commercehub.watershed.pump.model.PumpSettings;
 import com.commercehub.watershed.pump.service.TransformerFunctionFactory;
 import com.google.inject.Inject;

--- a/pump/src/main/java/com/commercehub/watershed/pump/processing/Pump.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/processing/Pump.java
@@ -25,7 +25,9 @@ import rx.observable.ListenableFutureObservable;
 import rx.schedulers.Schedulers;
 
 import java.nio.ByteBuffer;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * @author pmogren

--- a/pump/src/main/java/com/commercehub/watershed/pump/processing/Pump.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/processing/Pump.java
@@ -3,10 +3,10 @@ package com.commercehub.watershed.pump.processing;
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.producer.KinesisProducer;
 import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import com.commercehub.watershed.pump.model.DrillResultRow;
 import com.commercehub.watershed.pump.model.PumpRecord;
 import com.commercehub.watershed.pump.model.PumpRecordResult;
 import com.commercehub.watershed.pump.model.PumpSettings;
-import com.commercehub.watershed.pump.model.ResultRow;
 import com.commercehub.watershed.pump.respositories.DrillRepository;
 import com.commercehub.watershed.pump.service.KinesisService;
 import com.google.common.base.Function;
@@ -133,7 +133,7 @@ public class Pump {
                             .clone()
                             .withData(ByteBuffer.wrap(transformedData));
 
-                    return new PumpRecord(transformedKinesisRecord, pumpRecord.getDrillRow());
+                    return new PumpRecord(transformedKinesisRecord, pumpRecord.getDrillResultRow());
                 }
             });
         }
@@ -150,7 +150,7 @@ public class Pump {
                         Record kinesisRecord = pumpRecord.getKinesisRecord();
 
                         return ListenableFutureObservable.from(
-                                combine(kinesisProducer.addUserRecord(pumpSettings.getStreamOut(), kinesisRecord.getPartitionKey(), kinesisRecord.getData()), pumpRecord.getDrillRow()),
+                                combine(kinesisProducer.addUserRecord(pumpSettings.getStreamOut(), kinesisRecord.getPartitionKey(), kinesisRecord.getData()), pumpRecord.getDrillResultRow()),
                                 Schedulers.io());
                     }
                 });
@@ -175,12 +175,12 @@ public class Pump {
     }
 
     //Combine Future<UserRecordResult> and Record
-    private ListenableFuture<PumpRecordResult> combine(ListenableFuture<UserRecordResult> futureUserRecordResult, final ResultRow resultRow) {
+    private ListenableFuture<PumpRecordResult> combine(ListenableFuture<UserRecordResult> futureUserRecordResult, final DrillResultRow drillResultRow) {
 
         return Futures.transform(futureUserRecordResult, new AsyncFunction<UserRecordResult, PumpRecordResult>() {
 
             public ListenableFuture<PumpRecordResult> apply(final UserRecordResult userRecordResult) throws Exception {
-                return Futures.immediateFuture(new PumpRecordResult(userRecordResult, resultRow));
+                return Futures.immediateFuture(new PumpRecordResult(userRecordResult, drillResultRow));
             }
 
         });

--- a/pump/src/main/java/com/commercehub/watershed/pump/processing/PumpSubscriber.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/processing/PumpSubscriber.java
@@ -3,7 +3,7 @@ package com.commercehub.watershed.pump.processing;
 import com.commercehub.watershed.pump.model.Job;
 import com.commercehub.watershed.pump.model.ProcessingStage;
 import com.commercehub.watershed.pump.model.PumpRecordResult;
-import com.commercehub.watershed.pump.model.ResultRow;
+import com.commercehub.watershed.pump.model.DrillResultRow;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.name.Named;
@@ -26,7 +26,7 @@ public class PumpSubscriber extends Subscriber<PumpRecordResult> {
     private Job job;
     private Pump pump;
 
-    private ResultRow lastSuccessfulRow;
+    private DrillResultRow lastSuccessfulRow;
 
     @Inject
     public PumpSubscriber(
@@ -105,7 +105,7 @@ public class PumpSubscriber extends Subscriber<PumpRecordResult> {
         log.trace("Got a Kinesis result.");
         if (pumpRecordResult.getUserRecordResult().isSuccessful()) {
             successCount.incrementAndGet();
-            lastSuccessfulRow = pumpRecordResult.getResultRow();
+            lastSuccessfulRow = pumpRecordResult.getDrillResultRow();
         }
         else {
             failCount.incrementAndGet();

--- a/pump/src/main/java/com/commercehub/watershed/pump/processing/PumpSubscriber.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/processing/PumpSubscriber.java
@@ -1,8 +1,8 @@
 package com.commercehub.watershed.pump.processing;
 
-import com.commercehub.watershed.pump.model.PumpRecordResult;
 import com.commercehub.watershed.pump.model.Job;
 import com.commercehub.watershed.pump.model.ProcessingStage;
+import com.commercehub.watershed.pump.model.PumpRecordResult;
 import com.commercehub.watershed.pump.model.ResultRow;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;

--- a/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
@@ -1,9 +1,9 @@
 package com.commercehub.watershed.pump.respositories;
 
 
+import com.commercehub.watershed.pump.model.DrillResultRow;
 import com.commercehub.watershed.pump.model.JobPreview;
 import com.commercehub.watershed.pump.model.PreviewSettings;
-import com.commercehub.watershed.pump.model.ResultRow;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.slf4j.Logger;
@@ -60,19 +60,19 @@ public class DrillRepository implements QueryableRepository {
     }
 
 
-    public static ResultRow mapResultRow(ResultSet resultSet) throws SQLException{
+    public static DrillResultRow mapResultRow(ResultSet resultSet) throws SQLException{
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
 
-        ResultRow resultRow = new ResultRow();
+        DrillResultRow drillResultRow = new DrillResultRow();
         for(int i = 1; i <= resultSetMetaData.getColumnCount(); i++){
             if(resultSetMetaData.getColumnType(i) == Types.BOOLEAN){
-                resultRow.put(resultSetMetaData.getColumnName(i), String.valueOf(resultSet.getBoolean(i)));
+                drillResultRow.put(resultSetMetaData.getColumnName(i), String.valueOf(resultSet.getBoolean(i)));
                 continue;
             }
 
-            resultRow.put(resultSetMetaData.getColumnName(i), new String(resultSet.getBytes(i)));
+            drillResultRow.put(resultSetMetaData.getColumnName(i), new String(resultSet.getBytes(i)));
         }
 
-        return resultRow;
+        return drillResultRow;
     }
 }

--- a/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
@@ -1,9 +1,9 @@
 package com.commercehub.watershed.pump.respositories;
 
 
-import com.commercehub.watershed.pump.model.ResultRow;
 import com.commercehub.watershed.pump.model.JobPreview;
 import com.commercehub.watershed.pump.model.PreviewSettings;
+import com.commercehub.watershed.pump.model.ResultRow;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.slf4j.Logger;

--- a/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
@@ -1,6 +1,7 @@
 package com.commercehub.watershed.pump.respositories;
 
 
+import com.commercehub.watershed.pump.model.ResultRow;
 import com.commercehub.watershed.pump.model.JobPreview;
 import com.commercehub.watershed.pump.model.PreviewSettings;
 import com.google.inject.Inject;
@@ -10,7 +11,6 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,24 +51,28 @@ public class DrillRepository implements QueryableRepository {
     }
 
     private List<Map<String, String>> resultSetToList(ResultSet resultSet, Integer rowLimit) throws SQLException{
-        ResultSetMetaData md = resultSet.getMetaData();
-        int columns = md.getColumnCount();
         List<Map<String, String>> list = new ArrayList<>();
-
         while (resultSet.next() && resultSet.getRow() < rowLimit){
-            Map<String, String> row = new HashMap<>();
-            for(int i = 1; i <= columns; i++){
-                if(md.getColumnType(i) == Types.BOOLEAN){
-                    row.put(md.getColumnName(i), String.valueOf(resultSet.getBoolean(i)));
-                    continue;
-                }
-
-                row.put(md.getColumnName(i), new String(resultSet.getBytes(i)));
-            }
-
-            list.add(row);
+            list.add(mapResultRow(resultSet));
         }
 
         return list;
+    }
+
+
+    public static ResultRow mapResultRow(ResultSet resultSet) throws SQLException{
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+
+        ResultRow resultRow = new ResultRow();
+        for(int i = 1; i <= resultSetMetaData.getColumnCount(); i++){
+            if(resultSetMetaData.getColumnType(i) == Types.BOOLEAN){
+                resultRow.put(resultSetMetaData.getColumnName(i), String.valueOf(resultSet.getBoolean(i)));
+                continue;
+            }
+
+            resultRow.put(resultSetMetaData.getColumnName(i), new String(resultSet.getBytes(i)));
+        }
+
+        return resultRow;
     }
 }

--- a/pump/src/main/java/com/commercehub/watershed/pump/service/JobServiceImpl.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/service/JobServiceImpl.java
@@ -6,10 +6,8 @@ import com.commercehub.watershed.pump.model.Job;
 import com.commercehub.watershed.pump.model.JobPreview;
 import com.commercehub.watershed.pump.model.PreviewSettings;
 import com.commercehub.watershed.pump.model.PumpSettings;
-import com.commercehub.watershed.pump.processing.JobRunnable;
 import com.commercehub.watershed.pump.respositories.QueryableRepository;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 import java.sql.SQLException;
 import java.util.Collection;

--- a/pump/src/test/groovy/com/commercehub/watershed/pump/processing/PumpSpec.groovy
+++ b/pump/src/test/groovy/com/commercehub/watershed/pump/processing/PumpSpec.groovy
@@ -131,8 +131,7 @@ public class PumpSpec extends Specification {
         then:
         //subscriber is told about the record
         testSubscriber.assertNoErrors()
-        testSubscriber.assertReceivedOnNext([userRecordResult])
-        testSubscriber.assertValue(userRecordResult)
+        testSubscriber.assertValueCount(1)
         testSubscriber.assertCompleted()
     }
 
@@ -178,8 +177,7 @@ public class PumpSpec extends Specification {
         then:
         //subscriber is told about the transformed record
         testSubscriber.assertNoErrors()
-        testSubscriber.assertReceivedOnNext([userRecordResult])
-        testSubscriber.assertValue(userRecordResult)
+        testSubscriber.assertValueCount(1)
         testSubscriber.assertCompleted()
     }
 

--- a/pump/src/test/groovy/com/commercehub/watershed/pump/processing/PumpSubscriberSpec.groovy
+++ b/pump/src/test/groovy/com/commercehub/watershed/pump/processing/PumpSubscriberSpec.groovy
@@ -3,7 +3,9 @@ package com.commercehub.watershed.pump.processing
 import com.amazonaws.services.kinesis.producer.UserRecordResult
 import com.commercehub.watershed.pump.model.Job
 import com.commercehub.watershed.pump.model.ProcessingStage
+import com.commercehub.watershed.pump.model.PumpRecordResult
 import com.commercehub.watershed.pump.model.PumpSettings
+import com.commercehub.watershed.pump.model.ResultRow
 import rx.Producer
 import spock.lang.Specification
 
@@ -198,7 +200,7 @@ public class PumpSubscriberSpec extends Specification {
         userRecordResult.isSuccessful() >> true
 
         when:
-        pumpSubscriber.onNext(userRecordResult)
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
 
         then:
         pumpSubscriber.successCount.get() == 1
@@ -209,7 +211,7 @@ public class PumpSubscriberSpec extends Specification {
         userRecordResult.isSuccessful() >> false
 
         when:
-        pumpSubscriber.onNext(userRecordResult)
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
 
         then:
         pumpSubscriber.failCount.get() == 1
@@ -220,7 +222,7 @@ public class PumpSubscriberSpec extends Specification {
         userRecordResult.isSuccessful() >> true
 
         when:
-        pumpSubscriber.onNext(userRecordResult)
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
 
         then:
         pumpSubscriber.successCount.get() == 1
@@ -233,7 +235,7 @@ public class PumpSubscriberSpec extends Specification {
 
         when:
         pumpSubscriber.successCount = new AtomicLong(3L)
-        pumpSubscriber.onNext(userRecordResult)
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
 
         then:
         job.successfulRecordCount != pumpSubscriber.successCount.get()
@@ -245,7 +247,7 @@ public class PumpSubscriberSpec extends Specification {
 
         when:
         pumpSubscriber.successCount = new AtomicLong(4L)
-        pumpSubscriber.onNext(userRecordResult)
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
 
         then:
         job.successfulRecordCount == pumpSubscriber.successCount.get()
@@ -254,7 +256,7 @@ public class PumpSubscriberSpec extends Specification {
     def "onNext doesn't do a new request chunk for middle of chunk processing"(){
         when:
         pumpSubscriber.successCount = new AtomicLong(3L)
-        pumpSubscriber.onNext(userRecordResult)
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
 
         then:
         0 * producer.request(_)
@@ -263,7 +265,7 @@ public class PumpSubscriberSpec extends Specification {
     def "onNext requests new chunk at end of chunk processing"(){
         when:
         pumpSubscriber.successCount = new AtomicLong(4L)
-        pumpSubscriber.onNext(userRecordResult)
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
 
         then:
         1 * producer.request(5)

--- a/pump/src/test/groovy/com/commercehub/watershed/pump/processing/PumpSubscriberSpec.groovy
+++ b/pump/src/test/groovy/com/commercehub/watershed/pump/processing/PumpSubscriberSpec.groovy
@@ -5,7 +5,7 @@ import com.commercehub.watershed.pump.model.Job
 import com.commercehub.watershed.pump.model.ProcessingStage
 import com.commercehub.watershed.pump.model.PumpRecordResult
 import com.commercehub.watershed.pump.model.PumpSettings
-import com.commercehub.watershed.pump.model.ResultRow
+import com.commercehub.watershed.pump.model.DrillResultRow
 import rx.Producer
 import spock.lang.Specification
 
@@ -200,7 +200,7 @@ public class PumpSubscriberSpec extends Specification {
         userRecordResult.isSuccessful() >> true
 
         when:
-        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(DrillResultRow)))
 
         then:
         pumpSubscriber.successCount.get() == 1
@@ -211,7 +211,7 @@ public class PumpSubscriberSpec extends Specification {
         userRecordResult.isSuccessful() >> false
 
         when:
-        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(DrillResultRow)))
 
         then:
         pumpSubscriber.failCount.get() == 1
@@ -222,7 +222,7 @@ public class PumpSubscriberSpec extends Specification {
         userRecordResult.isSuccessful() >> true
 
         when:
-        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(DrillResultRow)))
 
         then:
         pumpSubscriber.successCount.get() == 1
@@ -235,7 +235,7 @@ public class PumpSubscriberSpec extends Specification {
 
         when:
         pumpSubscriber.successCount = new AtomicLong(3L)
-        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(DrillResultRow)))
 
         then:
         job.successfulRecordCount != pumpSubscriber.successCount.get()
@@ -247,7 +247,7 @@ public class PumpSubscriberSpec extends Specification {
 
         when:
         pumpSubscriber.successCount = new AtomicLong(4L)
-        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(DrillResultRow)))
 
         then:
         job.successfulRecordCount == pumpSubscriber.successCount.get()
@@ -256,7 +256,7 @@ public class PumpSubscriberSpec extends Specification {
     def "onNext doesn't do a new request chunk for middle of chunk processing"(){
         when:
         pumpSubscriber.successCount = new AtomicLong(3L)
-        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(DrillResultRow)))
 
         then:
         0 * producer.request(_)
@@ -265,7 +265,7 @@ public class PumpSubscriberSpec extends Specification {
     def "onNext requests new chunk at end of chunk processing"(){
         when:
         pumpSubscriber.successCount = new AtomicLong(4L)
-        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(ResultRow)))
+        pumpSubscriber.onNext(new PumpRecordResult(userRecordResult, Mock(DrillResultRow)))
 
         then:
         1 * producer.request(5)


### PR DESCRIPTION
This is a branch of the "pump_client" branch, so please merge https://github.com/commercehub-oss/watershed/pull/60 first.

The last successfully processed record will now be part of the Job. In the case of an error, it will be nice to see the original record so an operator could use that in the next query issued if they wanted to not rerun everything up to the point of error.

- Wraps Drill record and Kinesis record in a new object: PumpRecord
- Pump now strictly works off of PumpRecords, generating PumpRecordResults
- When the subscriber gets notice that a record is successful, the Job is updated with Drill record as the lastSuccessfulRow