### PR TITLE
use getString to read values from ResultSet

### DIFF
--- a/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
@@ -78,17 +78,7 @@ public class DrillRepository implements QueryableRepository {
 
         DrillResultRow drillResultRow = new DrillResultRow();
         for(int i = 1; i <= resultSetMetaData.getColumnCount(); i++){
-            if(resultSetMetaData.getColumnType(i) == Types.BOOLEAN){
-                drillResultRow.put(resultSetMetaData.getColumnName(i), String.valueOf(resultSet.getBoolean(i)));
-                continue;
-            }
-
-            if(resultSetMetaData.getColumnType(i) == Types.BIGINT){
-                drillResultRow.put(resultSetMetaData.getColumnName(i), String.valueOf(resultSet.getLong(i)));
-                continue;
-            }
-
-            drillResultRow.put(resultSetMetaData.getColumnName(i), new String(resultSet.getBytes(i)));
+            drillResultRow.put(resultSetMetaData.getColumnName(i), resultSet.getString(i));
         }
 
         return drillResultRow;

--- a/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
+++ b/pump/src/main/java/com/commercehub/watershed/pump/respositories/DrillRepository.java
@@ -83,6 +83,11 @@ public class DrillRepository implements QueryableRepository {
                 continue;
             }
 
+            if(resultSetMetaData.getColumnType(i) == Types.BIGINT){
+                drillResultRow.put(resultSetMetaData.getColumnName(i), String.valueOf(resultSet.getLong(i)));
+                continue;
+            }
+
             drillResultRow.put(resultSetMetaData.getColumnName(i), new String(resultSet.getBytes(i)));
         }
 

--- a/pump/src/test/groovy/com/commercehub/watershed/pump/repositories/DrillRepositorySpec.groovy
+++ b/pump/src/test/groovy/com/commercehub/watershed/pump/repositories/DrillRepositorySpec.groovy
@@ -4,14 +4,12 @@ import com.commercehub.watershed.pump.model.JobPreview
 import com.commercehub.watershed.pump.model.PreviewSettings
 import com.commercehub.watershed.pump.respositories.DrillRepository
 import com.google.inject.Provider
-import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.ResultSetMetaData
 import java.sql.Statement
-import java.sql.Types
 
 class DrillRepositorySpec extends Specification{
     DrillRepository drillRepository

--- a/pump/src/test/groovy/com/commercehub/watershed/pump/repositories/DrillRepositorySpec.groovy
+++ b/pump/src/test/groovy/com/commercehub/watershed/pump/repositories/DrillRepositorySpec.groovy
@@ -4,6 +4,7 @@ import com.commercehub.watershed.pump.model.JobPreview
 import com.commercehub.watershed.pump.model.PreviewSettings
 import com.commercehub.watershed.pump.respositories.DrillRepository
 import com.google.inject.Provider
+import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.sql.Connection
@@ -54,115 +55,4 @@ class DrillRepositorySpec extends Specification{
         jobPreview.count == 10
     }
 
-    def "getJobPreview handles boolean values with resultSetToList"(){
-        setup:
-        PreviewSettings previewSettings = new PreviewSettings(queryIn: "select * from foo", previewCount: 1)
-        resultSet.next() >> true
-        resultSet.getInt("total") >> 1
-        resultSetMetaData.getColumnCount() >> 1
-        resultSetMetaData.getColumnType(1) >> Types.BOOLEAN
-        resultSetMetaData.getColumnName(1) >> "bool"
-        resultSet.getBoolean(1) >> true
-
-        when:
-        JobPreview jobPreview = drillRepository.getJobPreview(previewSettings)
-
-        then:
-        2 * statement.executeQuery(_) >> resultSet
-        1 * resultSet.getRow() >> 0
-        resultSet.next() >> true
-
-        then:
-        1 * resultSet.getRow() >> 1
-        resultSet.next() >> false
-
-        then:
-        jobPreview.count == 1
-        jobPreview.rows.size() == 1
-        jobPreview.rows == [["bool":"true"]]
-    }
-
-    def "getJobPreview handles bigint values with resultSetToList"(){
-        setup:
-        PreviewSettings previewSettings = new PreviewSettings(queryIn: "select * from foo", previewCount: 1)
-        resultSet.next() >> true
-        resultSet.getInt("total") >> 1
-        resultSetMetaData.getColumnCount() >> 1
-        resultSetMetaData.getColumnType(1) >> Types.BIGINT
-        resultSetMetaData.getColumnName(1) >> "bigint"
-        resultSet.getLong(1) >> 1L
-
-        when:
-        JobPreview jobPreview = drillRepository.getJobPreview(previewSettings)
-
-        then:
-        2 * statement.executeQuery(_) >> resultSet
-        1 * resultSet.getRow() >> 0
-        resultSet.next() >> true
-
-        then:
-        1 * resultSet.getRow() >> 1
-        resultSet.next() >> false
-
-        then:
-        jobPreview.count == 1
-        jobPreview.rows.size() == 1
-        jobPreview.rows == [["bigint":"1"]]
-    }
-
-    def "getJobPreview handles String values with resultSetToList"(){
-        setup:
-        PreviewSettings previewSettings = new PreviewSettings(queryIn: "select * from foo", previewCount: 1)
-        resultSet.next() >> true
-        resultSet.getInt("total") >> 1
-        resultSetMetaData.getColumnCount() >> 1
-        resultSetMetaData.getColumnType(1) >> Types.VARCHAR
-        resultSetMetaData.getColumnName(1) >> "string"
-        resultSet.getBytes(1) >> "value".bytes
-
-        when:
-        JobPreview jobPreview = drillRepository.getJobPreview(previewSettings)
-
-        then:
-        2 * statement.executeQuery(_) >> resultSet
-        1 * resultSet.getRow() >> 0
-        resultSet.next() >> true
-
-        then:
-        1 * resultSet.getRow() >> 1
-        resultSet.next() >> false
-
-        then:
-        jobPreview.count == 1
-        jobPreview.rows.size() == 1
-        jobPreview.rows == [["string":"value"]]
-    }
-
-    def "getJobPreview handles Integer values with resultSetToList"(){
-        setup:
-        PreviewSettings previewSettings = new PreviewSettings(queryIn: "select * from foo", previewCount: 1)
-        resultSet.next() >> true
-        resultSet.getInt("total") >> 1
-        resultSetMetaData.getColumnCount() >> 1
-        resultSetMetaData.getColumnType(1) >> Types.INTEGER
-        resultSetMetaData.getColumnName(1) >> "integer"
-        resultSet.getBytes(1) >> "1".bytes
-
-        when:
-        JobPreview jobPreview = drillRepository.getJobPreview(previewSettings)
-
-        then:
-        2 * statement.executeQuery(_) >> resultSet
-        1 * resultSet.getRow() >> 0
-        resultSet.next() >> true
-
-        then:
-        1 * resultSet.getRow() >> 1
-        resultSet.next() >> false
-
-        then:
-        jobPreview.count == 1
-        jobPreview.rows.size() == 1
-        jobPreview.rows == [["integer":"1"]]
-    }
 }

--- a/pump/src/test/groovy/com/commercehub/watershed/pump/repositories/DrillRepositorySpec.groovy
+++ b/pump/src/test/groovy/com/commercehub/watershed/pump/repositories/DrillRepositorySpec.groovy
@@ -82,6 +82,34 @@ class DrillRepositorySpec extends Specification{
         jobPreview.rows == [["bool":"true"]]
     }
 
+    def "getJobPreview handles bigint values with resultSetToList"(){
+        setup:
+        PreviewSettings previewSettings = new PreviewSettings(queryIn: "select * from foo", previewCount: 1)
+        resultSet.next() >> true
+        resultSet.getInt("total") >> 1
+        resultSetMetaData.getColumnCount() >> 1
+        resultSetMetaData.getColumnType(1) >> Types.BIGINT
+        resultSetMetaData.getColumnName(1) >> "bigint"
+        resultSet.getLong(1) >> 1L
+
+        when:
+        JobPreview jobPreview = drillRepository.getJobPreview(previewSettings)
+
+        then:
+        2 * statement.executeQuery(_) >> resultSet
+        1 * resultSet.getRow() >> 0
+        resultSet.next() >> true
+
+        then:
+        1 * resultSet.getRow() >> 1
+        resultSet.next() >> false
+
+        then:
+        jobPreview.count == 1
+        jobPreview.rows.size() == 1
+        jobPreview.rows == [["bigint":"1"]]
+    }
+
     def "getJobPreview handles String values with resultSetToList"(){
         setup:
         PreviewSettings previewSettings = new PreviewSettings(queryIn: "select * from foo", previewCount: 1)


### PR DESCRIPTION
Warren ran into an error when using Pump with records containing a BIGINT field (in this case "kinesisSequenceNumber": "49557927932615281171020125420487954515345959974231605298"). This code is to add support for transforming BIGINT to a String when transforming Drill records.